### PR TITLE
fix for endtime issue

### DIFF
--- a/src/javascript/binary/pages/trade/price.js
+++ b/src/javascript/binary/pages/trade/price.js
@@ -76,7 +76,10 @@ var Price = (function() {
             if (!endTime2) {
                 var trading_times = Durations.trading_times();
                 if (trading_times.hasOwnProperty(endDate2) && typeof trading_times[endDate2][underlying.value] === 'object' && trading_times[endDate2][underlying.value].length && trading_times[endDate2][underlying.value][0] !== '--') {
-                    endTime2 = trading_times[endDate2][underlying.value];
+                    if( trading_times[endDate2][underlying.value].length>1)
+                        endTime2 = trading_times[endDate2][underlying.value][1];
+                    else
+                         endTime2=trading_times[endDate2][underlying.value];
                 }
             }
 


### PR DESCRIPTION
Fix for [trello card](https://trello.com/c/nT2GbLE5/84-selecting-duration-as-end-time-for-any-index-shows-incorrect-error-message).